### PR TITLE
update version to 0.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "anaconda-cloud-auth" %}
-{% set version = "0.1.4" %}
+{% set version = "0.4.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/anaconda_cloud_auth-{{ version }}.tar.gz
-  sha256: f0f029d7c87dc86ff15c005d2387d102a56d861ec64559a734dd032103d768bf
+  sha256: ff61aab300fa174a4ee02578e22be81ee1e093a9aa75d835e232130ac75894df
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
@@ -16,13 +16,13 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.8,<3.12
     - hatchling
     - hatch-vcs >=0.3
     - setuptools-scm >=7.1
     - pip
   run:
-    - python
+    - python >=3.8,<3.12
     - keyring
     - pkce
     - python-dotenv


### PR DESCRIPTION
anaconda-cloud-auth-feedstock 0.4.1

**Destination channel:** defaults

### Links

- [PKG-3943](https://anaconda.atlassian.net/browse/PKG-3943) 
- [Upstream repository](https://pypi.org/project/anaconda-cloud-auth/)

### Explanation of changes:

- Update version
- Update SHA
- Pin version number ranges


[PKG-3943]: https://anaconda.atlassian.net/browse/PKG-3943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ