### PR TITLE
update version to 0.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,13 +16,13 @@ build:
 
 requirements:
   host:
-    - python >=3.8,<3.12
+    - python
     - hatchling
     - hatch-vcs >=0.3
     - setuptools-scm >=7.1
     - pip
   run:
-    - python >=3.8,<3.12
+    - python
     - keyring
     - pkce
     - python-dotenv
@@ -49,6 +49,7 @@ about:
     for requests made to Anaconda Cloud services.
   home: https://anaconda.cloud
   doc_url: https://pypi.org/project/anaconda-cloud-auth/
+  dev_url: https://pypi.org/project/anaconda-cloud-auth/
   license: BSD-3-Clause
   license_file: LICENSE
   license_family: BSD

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pip
   run:
     - python
-    - keyring
+    - keyring # [not win]
     - pkce
     - python-dotenv
     - pydantic <2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pip
   run:
     - python
-    - keyring <=23.13.1
+    - keyring
     - pkce
     - python-dotenv
     - pydantic <2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ test:
 about:
   summary: A client auth library for Anaconda.cloud APIs
   description: |
-    A client library for Anaconda.cloud APIs to authenticate and securely store API keys.
+    A client library for Anaconda.cloud APIs to authenticate & securely store API keys.
     This package also provides a requests client class that handles loading the API key 
     for requests made to Anaconda Cloud services.
   home: https://anaconda.cloud

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - requests
     - cryptography >=3.4.0
     - semver <3
+    - pywin32-ctypes 0.2.2  # [win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pip
   run:
     - python
-    - keyring # [not win]
+    - keyring
     - pkce
     - python-dotenv
     - pydantic <2.0
@@ -31,8 +31,6 @@ requirements:
     - requests
     - cryptography >=3.4.0
     - semver <3
-    - pywin32-ctypes 0.2.2  # [win]
-
 test:
   imports:
     - anaconda_cloud_auth

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
 about:
   summary: A client auth library for Anaconda.cloud APIs
   description: |
-    A client library for Anaconda.cloud APIs to authenticate & securely store API keys.
+    A client library for Anaconda.cloud APIs to authenticate and securely store API keys.
     This package also provides a requests client class that handles loading the API key 
     for requests made to Anaconda Cloud services.
   home: https://anaconda.cloud

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - keyring
     - pkce
     - python-dotenv
-    - pydantic <2.0
+    - pydantic
     - pyjwt
     - requests
     - cryptography >=3.4.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "anaconda-cloud-auth" %}
-{% set version = "0.1.4" %}
+{% set version = "0.4.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/anaconda_cloud_auth-{{ version }}.tar.gz
-  sha256: f0f029d7c87dc86ff15c005d2387d102a56d861ec64559a734dd032103d768bf
+  sha256: ff61aab300fa174a4ee02578e22be81ee1e093a9aa75d835e232130ac75894df
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
@@ -16,13 +16,13 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.8,<3.12
     - hatchling
     - hatch-vcs >=0.3
     - setuptools-scm >=7.1
     - pip
   run:
-    - python
+    - python >=3.8,<3.12
     - keyring
     - pkce
     - python-dotenv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - python
     - hatchling
     - hatch-vcs >=0.3
-    - setuptools-scm >=7.1
     - pip
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pip
   run:
     - python
-    - keyring
+    - keyring <=23.13.1
     - pkce
     - python-dotenv
     - pydantic <2.0


### PR DESCRIPTION
anaconda-cloud-auth-feedstock 0.4.1

**Destination channel:** defaults

### Links

- [PKG-3943](https://anaconda.atlassian.net/browse/PKG-3943) 
- [Upstream repository](https://pypi.org/project/anaconda-cloud-auth/)

### Explanation of changes:

- Update version
- Update SHA
- Pin version number ranges


[PKG-3943]: https://anaconda.atlassian.net/browse/PKG-3943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ