### PR TITLE
Release 0.12.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,7 @@ outputs:
         - pyproject.toml
       requires:
         - pip
+        - conda
       imports:
         - anaconda_auth
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/anaconda/anaconda-auth/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed
+  sha256: 6e952baf3ca2276b660187895b620274428f22a6576edd734ac490e22bb88279
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,10 @@ requirements:
 outputs:
   - name: anaconda-auth
     build:
-      script: python -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+      script:
+        - python -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+        # Do not use python -m ... here to avoid unnecessary imports
+        - python ./src/anaconda_auth/_conda/config.py --install
       entry_points:
       - conda-token = anaconda_auth._conda.conda_token:cli
     requirements:
@@ -59,6 +62,7 @@ outputs:
       commands:
         - pip check
         - python -c "from anaconda_auth import __version__; assert __version__ == '{{ version }}'"
+        - python -m anaconda_auth._conda.config --verify
   - name: anaconda-cloud-auth
     requirements:
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/anaconda/anaconda-auth/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 072912f634e6662266d54ac2ed9827725fe53789270c91c4c47f2a4db4e8c3d4
+  sha256: 7d01ae70843dec2ad8f52f39c481880fb0cab408a148a4a3eec8f30ed6b3a2e5
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/anaconda/anaconda-auth/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 7d01ae70843dec2ad8f52f39c481880fb0cab408a148a4a3eec8f30ed6b3a2e5
+  sha256: d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.12.0" %}
+{% set version = "0.12.1" %}
 
 package:
   name: anaconda-cloud-auth-split


### PR DESCRIPTION
`anaconda-auth v0.12.1`

**Destination channel:** {Snowflake | defaults}

### Links

- [Upstream Release](https://github.com/anaconda/anaconda-auth/releases/tag/v0.12.1)

### Explanation of changes:

- Add configuration generation and validation steps to recipe.