### PR TITLE
v0.14.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.13.1" %}
+{% set version = "0.14.2" %}
 
 package:
   name: anaconda-cloud-auth-split
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/anaconda/anaconda-auth/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 8471cba04131bf335b02588d51716b2bde0898fadd0a9d2606d643f4dcafa251
+  sha256: 043ecbb5de7f1ef13ba3edd001c48c9b51bd9ba4dfdbbe0f70aa3c40fb4910d4
 
 build:
   number: 0


### PR DESCRIPTION
anaconda-auth v0.14.2

**Destination channel:** defaults

### Links

- [PKG-13174](https://anaconda.atlassian.net/browse/PKG-13174) 
- [Upstream repository](https://github.com/anaconda/anaconda-auth/tree/v0.14.2)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-auth/releases/tag/v0.14.2)

### Explanation of changes:

- Bump version and SHA


[PKG-13174]: https://anaconda.atlassian.net/browse/PKG-13174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ